### PR TITLE
5 mount dev from host to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,22 @@
 # barracuda-imu
 
-## Do the following IF `docker-compose.yml` DOES NOT EXIST:
-
-### Build docker image from dockerfile
-1. Make sure you have Docker Desktop installed and running on your host machine.
-2. Open a terminal shell in the base directory of this repository.
-```bash
-docker build -t barracuda-imu-node .
-```
-3. You should now have a docker image named `barracuda-imu-node`.
-4. WARNING: Each time you run this command, a new image is created. Building from `docker-compose.yml` is preferred.
-
-### Run docker image `barracuda-imu-node` in interactive mode
-1. Open a terminal shell in the base directory of this repository.
-```bash
-docker run -it barracuda-imu-node
-```
-
-## Do the following IF `docker-compose.yml` DOES EXIST:
 ### To Build and Start Container 
 ```
 docker compose up -d
 ```
 
-### To Stop and Remove All Images and Orphans 
+### To Enter the Container in Shell Mode
+```
+docker exec -it barracuda-imu /bin/bash
+```
+
+### To Exit the Container in Shell Mode
+```
+exit
+```
+
+### To Shut Down the Container and all Orphans 
 ```
 docker compose down --remove-orphans --rmi all
 ```
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,4 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    user: root
     container_name: barracuda-imu
+    tty: true
+    network_mode: host
+    restart: no

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,3 +8,6 @@ services:
     tty: true
     network_mode: host
     restart: no
+    privileged: true
+    volumes:
+      - /dev:/dev

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ source /opt/ros/noetic/setup.bash
 # Build catkin_ws
 cd barracuda-imu/catkin_ws
 catkin_make
+source devel/setup.bash
 
 # Start interactive shell session in /opt/barracuda-imu directory
 cd ..


### PR DESCRIPTION
Mounted host /dev directory in container. 

Example of /dev working using command `ls /dev`:
![image](https://github.com/user-attachments/assets/3bd3719d-7bc4-4c6d-99cb-d5573915c85f)